### PR TITLE
Add yank support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ EOF
 local opts = { noremap = true, silent = true }
 
 vim.keymap.set("n", "<Leader><Leader>i", "<cmd>PickEverything<cr>", opts)
+vim.keymap.set("n", "<Leader><Leader>y", "<cmd>PickEverythingYank<cr>", opts)
 vim.keymap.set("i", "<C-i>", "<cmd>PickEverythingInsert<cr>", opts)
 ```
 
@@ -60,6 +61,14 @@ I personally use `<C-i>` for `PickIconsInsert`. If you also want to map `<C-I>` 
   - `PickSymbols`
   - `PickAltFont`
   - `PickAltFontAndSymbols`
+- Normal Mode (yank):
+  - `PickEverythingYank` (Nerd Font Icons & Emojis & Alt Font & Symbols)
+  - `PickIconsYank` (Nerd Font Icons & Emojis)
+  - `PickEmojiYank`
+  - `PickNerdYank`
+  - `PickSymbolsYank`
+  - `PickAltFontYank`
+  - `PickAltFontAndSymbolsYank`
 - Insert Mode:
   - `PickEverythingInsert` (Nerd Font Icons & Emojis & Alt Font & Symbols)
   - `PickIconsInsert` (Nerd Font Icons & Emojis)

--- a/lua/icon-picker/init.lua
+++ b/lua/icon-picker/init.lua
@@ -60,6 +60,16 @@ local function insert_user_choice_normal(choice)
 	end
 end
 
+local function yank_user_choice_normal(choice)
+	if choice then
+		local split = vim.split(choice, " ")
+
+		vim.schedule(function()
+			vim.cmd("let @+='" .. split[1] .. "'")
+		end)
+	end
+end
+
 local function insert_user_choice_insert(choice)
 	if choice then
 		local split = vim.split(choice, " ")
@@ -115,6 +125,10 @@ end -- }}}
 for type, data in pairs(list_types) do
 	vim.api.nvim_create_user_command(type, function()
 		generate_list(data["icon_types"], data["desc"], insert_user_choice_normal)
+	end, {})
+
+	vim.api.nvim_create_user_command(type .. "Yank", function()
+		generate_list(data["icon_types"], data["desc"], yank_user_choice_normal)
 	end, {})
 
 	vim.api.nvim_create_user_command(type .. "Insert", function()


### PR DESCRIPTION
Hi @ziontee113,

Just want to say great work on the plugin. I really enjoy having these symbols integrated into vim!

There was one thing that I kept doing when using the plugin that I think this PR addresses: 

1. select symbol in normal mode
2. deleting symbol to put in my register
3. pasting it somewhere else (perhaps outside of vim)

In order to simplify this process, I have added another group of commands with `Yank` as a suffix (e.g. `PickEmojiYank`) that takes the selection and assigns it to the clipboard register `+`.

Unfortunately, this adds many more commands to the package (14 -> 21), which crowds the command namespace when entering into command mode with `:P` and hitting tab. I will open an issue after publishing this PR detailing what exactly I mean by that and a potential API change to improve design.

Anways, thanks again for the cool package!

EDIT: link to issue #8 