### PR TITLE
fix: add `kind` option to `vim.ui.select`

### DIFF
--- a/lua/icon-picker/init.lua
+++ b/lua/icon-picker/init.lua
@@ -107,6 +107,7 @@ end
 local function custom_ui_select(items, prompt, callback)
 	vim.ui.select(items, {
 		prompt = prompt,
+		kind = "icon_picker",
 	}, callback)
 end
 


### PR DESCRIPTION
This allows you to configure dressing to select different selectors based on the type of selection you are making.