### PR TITLE
Added dressing dependency to installation instruction using Lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ For Lazy
 
 ```lua
 {
-    'stevearc/dressing.nvim',
-    opts = {},
-},
-{
     "ziontee113/icon-picker.nvim",
+    dependencies = {
+        "stevearc/dressing.nvim",
+    },
     config = function()
         require("icon-picker").setup({ disable_legacy_commands = true })
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ For Lazy
 
 ```lua
 {
+    'stevearc/dressing.nvim',
+    opts = {},
+},
+{
     "ziontee113/icon-picker.nvim",
     config = function()
         require("icon-picker").setup({ disable_legacy_commands = true })


### PR DESCRIPTION
After struggling for a while, I figured out that in the other installation methods, they were using the plugin "dressing",  and I think it's worth adding that info for Lazy too. I'm a newbie with LunarVim, and installing a plugin was uncharted territory for me. I had no clue where to drop the code for the plugin installation. Sunday turned out to be quite a mix of interesting and frustrating, lol.